### PR TITLE
Handle missing Gemini API client

### DIFF
--- a/components/AIEnhancer.tsx
+++ b/components/AIEnhancer.tsx
@@ -29,7 +29,11 @@ export default function AIEnhancer({ sourceName, targetName, transformation, mor
       setNames(result);
     } catch (err) {
       console.error('Gemini API error:', err);
-      setError('Could not generate names. The AI might be sleeping.');
+      if (err instanceof Error && err.message === 'Gemini API client not configured.') {
+        setError('AI features are disabled. Please set the Gemini API key.');
+      } else {
+        setError('Could not generate names. The AI might be sleeping.');
+      }
     } finally {
       setIsLoading(false);
     }

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -9,7 +9,7 @@ if (!API_KEY) {
   console.warn("Gemini API key not found. AI features will be disabled.");
 }
 
-const ai = new GoogleGenAI({ apiKey: API_KEY! });
+const ai = API_KEY ? new GoogleGenAI({ apiKey: API_KEY }) : null;
 
 const nameGenerationSchema = {
   type: Type.OBJECT,
@@ -33,8 +33,8 @@ export async function generateSoundName(
   morphA?: TransformationType,
   morphB?: TransformationType
 ): Promise<string[]> {
-  if (!API_KEY) {
-    throw new Error("API key is not configured.");
+  if (!ai) {
+    throw new Error("Gemini API client not configured.");
   }
   
   let transformationDescription = `The transformation technique used was: "${transformation}".`;


### PR DESCRIPTION
## Summary
- Instantiate Gemini client only when API key is provided.
- Guard `generateSoundName` and UI name generation with clear errors when AI is disabled.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68977736b3948325a4e4bf2c34e8afd7