### PR TITLE
chore(ci): add SBOM generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
       - name: Build (Vite)
         run: npm run build --if-present
 
+      - name: SBOM (CycloneDX)
+        run: npx --yes @cyclonedx/cyclonedx-npm --output-file sbom.json
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.json
+
       - name: Analyze bundle (optional)
         run: 'npx --yes source-map-explorer "dist/assets/*.js" --html report.html || true'
 


### PR DESCRIPTION
## Summary
- generate CycloneDX SBOM after build and upload as artifact

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68971e8fce7883259bf619159c9c5ffb