### PR TITLE
chore: harden CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: ci
+permissions:
+  contents: read
+  actions: none
+  checks: write
 on:
   push:
     branches: [ "main" ]
@@ -7,14 +11,19 @@ on:
 jobs:
   diagnose-and-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
 
       - name: Show env proxy-related vars
         run: 'env | grep -i -E "proxy|npm_config" || true'
@@ -29,7 +38,7 @@ jobs:
         run: npm ping
 
       - name: Clean install
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build (Vite)
         run: npm run build --if-present


### PR DESCRIPTION
## Summary
- tighten workflow permissions
- harden checkout and setup steps
- skip scripts during clean install

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68971e8cdd6c8325a009b494d601620d