### PR TITLE
Add Vitest test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:ci": "vitest run --coverage"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -17,6 +20,7 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^2.1.4"
   }
 }


### PR DESCRIPTION
## Summary
- add npm scripts for running Vitest with coverage options
- include Vitest as a dev dependency

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689711ec8fe48325b1c5d6d7ffa62f80